### PR TITLE
dependabot: Enable more grouped updates for GitHub Actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# the following users/teams will be requested for
+# review when someone opens a pull request.
+* @bloomberg/org-owners

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     groups:
-      github:
+      github-actions:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "actions/*"
+          - "github/*"
+      github-owned-actions:
         patterns:
           - "actions/*"
           - "github/*"

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -11,5 +11,4 @@ jobs:
       - name: 🧹 lint yaml
         uses: ibiqlik/action-yamllint@v3
         with:
-          file_or_dir: "org/**/*.yaml"
           config_file: ".yamllint.yml"


### PR DESCRIPTION
Explicitly groups GitHub-owned actions separately.